### PR TITLE
coral-dev: Set blink to unsupported

### DIFF
--- a/coral-dev.coffee
+++ b/coral-dev.coffee
@@ -32,6 +32,8 @@ module.exports =
 		osx: 'http://docs.resin.io/coral-dev/nodejs/getting-started/#adding-your-first-device'
 		linux: 'http://docs.resin.io/coral-dev/nodejs/getting-started/#adding-your-first-device'
 
+	supportsBlink: false
+
 	yocto:
 		machine: 'coral-dev'
 		image: 'resin-image-flasher'


### PR DESCRIPTION
Noticed I was missing this in the coffee file so let's ensure the icon doesn't show up in the dashboard.