### PR TITLE
coral-dev: Add sd step after switching boot pins

### DIFF
--- a/coral-dev.coffee
+++ b/coral-dev.coffee
@@ -24,6 +24,7 @@ module.exports =
 	instructions: [
 		SWITCH_SD
 		instructions.ETCHER_SD
+		instructions.EJECT_SD
 		instructions.FLASHER_WARNING
 	].concat(postProvisioningInstructions)
 


### PR DESCRIPTION
Step eject_sd from common instructions needs to
be mentioned as step 4 in the dashboard, right after
switching boot pins to emmc.

