### PR TITLE
Changes for starting weston in container

### DIFF
--- a/layers/meta-balena-coral/recipes-core/images/resin-image.inc
+++ b/layers/meta-balena-coral/recipes-core/images/resin-image.inc
@@ -20,7 +20,6 @@ IMAGE_CMD_resinos-img_append () {
 IMAGE_INSTALL_append = " \
     imx-board-wlan \
     coral-imx-firmware \
-    kernel-module-imx-gpu-viv \
 "
 
 DEPENDS += " \

--- a/layers/meta-balena-coral/recipes-kernel/linux/linux-coral_%.bbappend
+++ b/layers/meta-balena-coral/recipes-kernel/linux/linux-coral_%.bbappend
@@ -9,3 +9,9 @@ RESIN_CONFIGS_append = " \
 RESIN_CONFIGS[cfg80211_builtin] = " \
     CONFIG_CFG80211=y \
 "
+
+# This helps the kernel version
+# match the one of the container installed
+# galcore module from imx-gpu-viv deb
+LOCALVERSION = "-imx"
+SCMVERSION="n"


### PR DESCRIPTION
The imx-gpu driver from BSP is not suitable for the google coral board as it makes weston crash
when started from the container.

Remove this oot module from the rootfs and instead use the one from imx-gpu-viv deb package as we'll do in our sample APP for the google coral dev: https://github.com/balena-io-playground/google-coral-dev-sample/pull/2