### PR TITLE
coral-dev.coffee: Set private to false for the public device types

### DIFF
--- a/coral-dev.coffee
+++ b/coral-dev.coffee
@@ -17,6 +17,7 @@ module.exports =
 	name: 'Google Coral Dev Board'
 	arch: 'aarch64'
 	state: 'new'
+	private: false
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types

Signed-off-by: Florin Sarbu <florin@balena.io>