### PR TITLE
Fix deep suspend resume on ttymxc2

### DIFF
--- a/layers/meta-balena-coral/recipes-bsp/imx-atf/imx-atf_%.bbappend
+++ b/layers/meta-balena-coral/recipes-bsp/imx-atf/imx-atf_%.bbappend
@@ -1,0 +1,10 @@
+PV = "2.0+git${SRCPV}"
+
+# Switch from meta-freescale imx-atf on warrior
+# to the one used by google in release-day, to
+# solve deep suspend/resume issue.
+SRCBRANCH = "release-day"
+SRC_URI = "git://coral.googlesource.com/imx-atf.git;protocol=https;branch=${SRCBRANCH} \
+           file://0001-Allow-BUILD_STRING-to-be-set-in-.revision-file.patch \
+"
+SRCREV = "d543fbbb7d72eda0c5aed97d7a50d78f6aefb09f"


### PR DESCRIPTION
If entering deep sleep with
```
echo enabled > /sys/devices/platform/30880000.serial/tty/ttymxc2/power/wakeup
echo mem > /sys/power/state
```
or, as recommended, with 
`systemctl suspend`
and then sent chars over UART3, the target did now wake up. This was caused by the atf version provided by warrior.

With this change resume now works and wifi & bt are also up and running after resume.