### PR TITLE
coral-dev: Re-label device in dashboard

### DIFF
--- a/coral-dev.coffee
+++ b/coral-dev.coffee
@@ -14,7 +14,7 @@ postProvisioningInstructions = [
 module.exports =
 	version: 1
 	slug: 'coral-dev'
-	name: 'Google Coral Dev Board'
+	name: 'Coral Dev Board'
 	arch: 'aarch64'
 	state: 'new'
 	private: false


### PR DESCRIPTION
Outreach team asked to have this device
type renamed to Coral Dev Board

Changelog-entry: coral-dev: Re-label device in dashboard
Signed-off-by: Alexandru Costache <alexandru@balena.io>