### PR TITLE
asus-tinker-edge-t.coffee: Mark board as community

### DIFF
--- a/asus-tinker-edge-t.coffee
+++ b/asus-tinker-edge-t.coffee
@@ -17,6 +17,7 @@ module.exports =
 	name: 'ASUS Tinker Edge T'
 	arch: 'aarch64'
 	state: 'new'
+	community: true
 
 	stateInstructions:
 		postProvisioning: postProvisioningInstructions


### PR DESCRIPTION
Changelog-entry: Mark asus-tinker-edge-t as a community board
Signed-off-by: Florin Sarbu <florin@balena.io>