### PR TITLE
balena-image-initramfs: Remove unused modules

### DIFF
--- a/layers/meta-balena-coral/recipes-core/images/balena-image-initramfs.bbappend
+++ b/layers/meta-balena-coral/recipes-core/images/balena-image-initramfs.bbappend
@@ -1,0 +1,4 @@
+# There is no sufficient space in the rootfs and probably we won't need to migrate on these device types
+# also we don't need the recovery module since we have a separate debug uart
+PACKAGE_INSTALL_remove = " initramfs-module-recovery
+PACKAGE_INSTALL_remove = "initramfs-module-migrate"


### PR DESCRIPTION
Because the device types in this repo are not a target for migration. Also we have a dedicated debug uart on this board so we can also remove the recovery module.
We need to remove these modules because we are running out of space in the rootfs and this makes HUP error.

Changelog-entry: balena-image-initramfs: Remove unused modules